### PR TITLE
Observability Suite Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## 01 - Install Consul
 
 - kind create cluster --config=kind/cluster.yaml
-- helm install --values helm/consul-v1.yaml consul hashicorp/consul --create-namespace --namespace consul --version "0.48.0"
+- helm install --values helm/consul-values-v1.yaml consul hashicorp/consul --create-namespace --namespace consul --version "0.48.0"
 - kubectl port-forward svc/consul-ui --namespace consul 6443:443
 - [Consul UI](https://localhost:6443/ui/)
 
@@ -17,7 +17,7 @@
 ## 03 - Ingress with Consul on Kubernetes
 
 - kubectl apply --kustomize "github.com/hashicorp/consul-api-gateway/config/crd?ref=v0.4.0"
-- helm upgrade --values helm/consul-v2.yaml consul hashicorp/consul --namespace consul --version "0.48.0"
+- helm upgrade --values helm/consul-values-v2.yaml consul hashicorp/consul --namespace consul --version "0.48.0"
 - kubectl apply --filename api-gw/consul-api-gateway.yaml --namespace consul && \
  kubectl wait --for=condition=ready gateway/api-gateway --namespace consul --timeout=90s && \
  kubectl apply --filename api-gw/routes.yaml --namespace consul
@@ -28,10 +28,11 @@
 
 ## 04 - Observability with Consul on Kubernetes
 
-- ./install-observability-suite.sh
-- helm upgrade --values helm/consul-v3.yaml consul hashicorp/consul --namespace consul --version "0.48.0"
+- helm upgrade --values helm/consul-values-v3.yaml consul hashicorp/consul --namespace consul --version "0.48.0"
 - kubectl apply -f proxy/proxy-defaults.yaml
-- kubectl apply -f hashicups/v3/
+- kubectl delete --filename hashicups/v1/ && \
+ kubectl apply --filename hashicups/v1/
+- ./install-observability-suite.sh
 - kubectl port-forward svc/consul-ui --namespace consul 6443:443
 - [Consul UI](https://localhost:6443/ui/)
 - kubectl port-forward svc/grafana --namespace default 3000:3000

--- a/local/install-observability-suite.sh
+++ b/local/install-observability-suite.sh
@@ -2,7 +2,7 @@ helm repo add prometheus-community https://prometheus-community.github.io/helm-c
 helm repo add grafana https://grafana.github.io/helm-charts && \
 helm install --values helm/prometheus.yaml prometheus prometheus-community/prometheus --version "15.5.3" && \
 kubectl rollout status deployment prometheus-server --namespace default --timeout=300s && \
-helm install loki grafana/loki-stack --version "2.6.5" && \
+helm install loki grafana/loki-stack --version "2.8.1" && \
 kubectl rollout status statefulset loki --namespace default --timeout=300s && \
 helm install --values helm/grafana.yaml grafana grafana/grafana --version "6.23.1" && \
 kubectl rollout status deployment grafana --namespace default --timeout=300s && \


### PR DESCRIPTION
# Description

After running this tutorial, a combination of the pre-requisites generated the following error when trying to run the observability suite commands:

```shell
Error: UPGRADE FAILED: resource mapping not found for name: "loki" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first
```
After changing the grafana/loki-stack version from 2.6.5 to 2.8.1, this issue resolved, as this appears to be the first version to remove the dependency on policy/v1beta1.

Prerequisite versions included below for reference:

| Prerequisite | Version |
| :------------: | :-------: |
| `consul` | `1.13.2` |
| `consul-k8s` | `0.48.0` |
| `docker` | `20.10.17` |
| `git` | `2.37.3` |
| `helm` | `3.10.0` |
| `kind` | `0.16.0` |
| `kubectl` | `1.25.2` |

