### PR TITLE
The apiGateway should be a subnode of connectInject

### DIFF
--- a/self-managed/local/helm/values-v2.yaml
+++ b/self-managed/local/helm/values-v2.yaml
@@ -48,14 +48,14 @@ connectInject:
     # Enables metrics for Consul Connect sidecars.
   metrics:
     defaultEnabled: true
-apiGateway:
-  enabled: true
-  # Image to use for the api-gateway-controller pods and gateway instances
-  image: "hashicorp/consul-api-gateway:0.5.1"
-  # Configuration settings for the GatewayClass
-  managedGatewayClass:
-    # Defines the type of service created for gateways (e.g. LoadBalancer, ClusterIP, NodePort)
-    # NodePort is primarily used for local deployments.
-    serviceType: NodePort
-    # Toggles the gateway ports to be mapped to host ports (used for local deployments)
-    useHostPorts: true
+  apiGateway:
+    enabled: true
+    # Image to use for the api-gateway-controller pods and gateway instances
+    image: "hashicorp/consul-api-gateway:0.5.1"
+    # Configuration settings for the GatewayClass
+    managedGatewayClass:
+      # Defines the type of service created for gateways (e.g. LoadBalancer, ClusterIP, NodePort)
+      # NodePort is primarily used for local deployments.
+      serviceType: NodePort
+      # Toggles the gateway ports to be mapped to host ports (used for local deployments)
+      useHostPorts: true


### PR DESCRIPTION
https://developer.hashicorp.com/consul/docs/k8s/helm#apigateway

This fixes a problem where applying values-v2 gives:

Error: UPGRADE FAILED: resource mapping not found for name: "consul-api-gateway" namespace: "" from "": no matches for kind "GatewayClassConfig" in version "api-gateway.consul.hashicorp.com/v1alpha1"

Fixes #7 