### PR TITLE
fix: update aws kubernetes and addon versions

### DIFF
--- a/hcp-managed/eks/aws.tf
+++ b/hcp-managed/eks/aws.tf
@@ -47,7 +47,7 @@ module "eks" {
   version = "19.5.1"
 
   cluster_name    = local.name
-  cluster_version = "1.24"
+  cluster_version = "1.32"
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.public_subnets
@@ -128,7 +128,7 @@ module "irsa-ebs-csi" {
 resource "aws_eks_addon" "ebs-csi" {
   cluster_name             = module.eks.cluster_name
   addon_name               = "aws-ebs-csi-driver"
-  addon_version            = "v1.20.0-eksbuild.1"
+  addon_version            = "v1.43.0-eksbuild.1"
   service_account_role_arn = module.irsa-ebs-csi.iam_role_arn
   tags = {
     "eks_addon" = "ebs-csi"


### PR DESCRIPTION
Kubernetes version 1.24 is no longer supported, see https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html.  I chose 1.32 as it is one version behind the latest in standard support.

ebs-csi version 1.20 is not compatible with kubernetes 1.32. I chose 1.43 to be compatible with kubernetes 1.32, as listed in `aws  eks describe-addon-versions --addon-name aws-ebs-csi-driver`.

`terraform apply` runs with these versions, and consul is running and reachable.

Discovered while doing the tutorial at https://developer.hashicorp.com/consul/tutorials/get-started-kubernetes/kubernetes-gs-deploy